### PR TITLE
Make RabbitServer's Queues and Exchanges public.

### DIFF
--- a/src/AddUp.FakeRabbitMQ/RabbitExchange.cs
+++ b/src/AddUp.FakeRabbitMQ/RabbitExchange.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace AddUp.RabbitMQ.Fakes
 {
-    internal sealed class RabbitExchange
+    public sealed class RabbitExchange
     {
         private readonly IBindingMatcher matcher;
         private readonly RabbitServer server;

--- a/src/AddUp.FakeRabbitMQ/RabbitExchangeQueueBinding.cs
+++ b/src/AddUp.FakeRabbitMQ/RabbitExchangeQueueBinding.cs
@@ -1,6 +1,6 @@
 ﻿namespace AddUp.RabbitMQ.Fakes
 {
-    internal sealed class RabbitExchangeQueueBinding
+    public sealed class RabbitExchangeQueueBinding
     {
         public string RoutingKey { get; set; }
         public RabbitExchange Exchange { get; set; }

--- a/src/AddUp.FakeRabbitMQ/RabbitMessage.cs
+++ b/src/AddUp.FakeRabbitMQ/RabbitMessage.cs
@@ -2,7 +2,7 @@
 
 namespace AddUp.RabbitMQ.Fakes
 {
-    internal sealed class RabbitMessage
+    public sealed class RabbitMessage
     {
         public string Exchange { get; set; }
         public string RoutingKey { get; set; }

--- a/src/AddUp.FakeRabbitMQ/RabbitQueue.cs
+++ b/src/AddUp.FakeRabbitMQ/RabbitQueue.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace AddUp.RabbitMQ.Fakes
 {
-    internal sealed class RabbitQueue
+    public sealed class RabbitQueue
     {
         private readonly HashSet<EventHandler<RabbitMessage>> messagePublishedEventHandlers;
 

--- a/src/AddUp.FakeRabbitMQ/RabbitServer.cs
+++ b/src/AddUp.FakeRabbitMQ/RabbitServer.cs
@@ -10,9 +10,9 @@ namespace AddUp.RabbitMQ.Fakes
             Queues = new ConcurrentDictionary<string, RabbitQueue>();
         }
 
-        internal ConcurrentDictionary<string, RabbitExchange> Exchanges { get; }
-        internal ConcurrentDictionary<string, RabbitQueue> Queues { get; }
-        
+        public ConcurrentDictionary<string, RabbitExchange> Exchanges { get; }
+        public ConcurrentDictionary<string, RabbitQueue> Queues { get; }
+
         public void Reset()
         {
             Exchanges.Clear();


### PR DESCRIPTION
Consequently make other types public that would otherwise result in compile errors due to inconsistent visibilities.

The motivation for this is that without exposing the server's Queues and Exchanges, it's impossible (or at least impractical to the point where I don't understand how) to assert about state in unit tests, which renders the library unusable for its intended purpose.