### PR TITLE
Add support for default exchange.

### DIFF
--- a/src/AddUp.FakeRabbitMQ.Tests/FakeModelBasicTests.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/FakeModelBasicTests.cs
@@ -263,6 +263,24 @@ namespace AddUp.RabbitMQ.Fakes
         }
 
         [Fact]
+        public void BasicPublish_to_default_exchange_publishes_message()
+        {
+            var server = new RabbitServer();
+            using (var model = new FakeModel(server))
+            {
+                model.QueueDeclare("my_queue");
+
+                var message = "hello world!";
+                var encodedMessage = Encoding.ASCII.GetBytes(message);
+
+                model.BasicPublish("", "my_queue", model.CreateBasicProperties(), encodedMessage);
+
+                Assert.Single(server.Queues["my_queue"].Messages);
+                Assert.Equal(encodedMessage, server.Queues["my_queue"].Messages.First().Body);
+            }
+        }
+
+        [Fact]
         public void BasicPublishBatch_publishes_messages()
         {
             var server = new RabbitServer();

--- a/src/AddUp.FakeRabbitMQ.Tests/FakeModelExchangeTests.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/FakeModelExchangeTests.cs
@@ -23,9 +23,10 @@ namespace AddUp.RabbitMQ.Fakes
                 var arguments = new Dictionary<string, object>();
 
                 model.ExchangeDeclare(exchange: exchangeName, type: exchangeType, durable: isDurable, autoDelete: isAutoDelete, arguments: arguments);
-                Assert.Single(server.Exchanges);
+                Assert.Equal(2, server.Exchanges.Count);
+                Assert.Single(server.Exchanges.Where(x => x.Key == exchangeName));
 
-                var exchange = server.Exchanges.First();
+                var exchange = server.Exchanges.Single(x => x.Key == exchangeName);
                 AssertEx.AssertExchangeDetails(exchange, exchangeName, isAutoDelete, arguments, isDurable, exchangeType);
             }
         }
@@ -41,9 +42,10 @@ namespace AddUp.RabbitMQ.Fakes
                 const bool isDurable = true;
 
                 model.ExchangeDeclare(exchange: exchangeName, type: exchangeType, durable: isDurable);
-                Assert.Single(server.Exchanges);
+                Assert.Equal(2, server.Exchanges.Count);
+                Assert.Single(server.Exchanges.Where(x => x.Key == exchangeName));
 
-                var exchange = server.Exchanges.First();
+                var exchange = server.Exchanges.Single(x => x.Key == exchangeName);
                 AssertEx.AssertExchangeDetails(exchange, exchangeName, false, null, isDurable, exchangeType);
             }
         }
@@ -58,9 +60,10 @@ namespace AddUp.RabbitMQ.Fakes
                 const string exchangeType = "someType";
 
                 model.ExchangeDeclare(exchange: exchangeName, type: exchangeType);
-                Assert.Single(server.Exchanges);
+                Assert.Equal(2, server.Exchanges.Count);
+                Assert.Single(server.Exchanges.Where(x => x.Key == exchangeName));
 
-                var exchange = server.Exchanges.First();
+                var exchange = server.Exchanges.Single(x => x.Key == exchangeName);
                 AssertEx.AssertExchangeDetails(exchange, exchangeName, false, null, false, exchangeType);
             }
         }
@@ -103,9 +106,10 @@ namespace AddUp.RabbitMQ.Fakes
                 var arguments = new Dictionary<string, object>();
 
                 model.ExchangeDeclareNoWait(exchange: exchangeName, type: exchangeType, durable: isDurable, autoDelete: isAutoDelete, arguments: arguments);
-                Assert.Single(server.Exchanges);
+                Assert.Equal(2, server.Exchanges.Count);
+                Assert.Single(server.Exchanges.Where(x => x.Key == exchangeName));
 
-                var exchange = server.Exchanges.First();
+                var exchange = server.Exchanges.Single(x => x.Key == exchangeName);
                 AssertEx.AssertExchangeDetails(exchange, exchangeName, isAutoDelete, arguments, isDurable, exchangeType);
             }
         }
@@ -119,7 +123,7 @@ namespace AddUp.RabbitMQ.Fakes
                 const string exchangeName = "someExchange";
                 model.ExchangeDeclare(exchangeName, "someType");
                 model.ExchangeDelete(exchange: exchangeName);
-                Assert.Empty(server.Exchanges);
+                Assert.Single(server.Exchanges);
             }
         }
 
@@ -134,7 +138,7 @@ namespace AddUp.RabbitMQ.Fakes
                 const string exchangeName = "someExchange";
                 model.ExchangeDeclare(exchangeName, "someType");
                 model.ExchangeDelete(exchange: exchangeName, ifUnused: ifUnused);
-                Assert.Empty(server.Exchanges);
+                Assert.Single(server.Exchanges);
             }
         }
 
@@ -149,7 +153,7 @@ namespace AddUp.RabbitMQ.Fakes
                 const string exchangeName = "someExchange";
                 model.ExchangeDeclare(exchangeName, "someType");
                 model.ExchangeDeleteNoWait(exchange: exchangeName, ifUnused: ifUnused);
-                Assert.Empty(server.Exchanges);
+                Assert.Single(server.Exchanges);
             }
         }
 
@@ -162,7 +166,8 @@ namespace AddUp.RabbitMQ.Fakes
                 const string exchangeName = "someExchange";
                 model.ExchangeDeclare(exchangeName, "someType");
                 model.ExchangeDelete(exchange: "someOtherExchange");
-                Assert.Single(server.Exchanges);
+                Assert.Equal(2, server.Exchanges.Count);
+                Assert.Single(server.Exchanges.Where(s => s.Key == exchangeName));
             }
         }
 
@@ -219,7 +224,7 @@ namespace AddUp.RabbitMQ.Fakes
                 model.ExchangeUnbind(queueName, exchangeName, routingKey, arguments);
 
                 Assert.True(server.Exchanges[exchangeName].Bindings.IsEmpty);
-                Assert.True(server.Queues[queueName].Bindings.IsEmpty);
+                Assert.Single(server.Queues[queueName].Bindings);
             }
         }
 
@@ -240,7 +245,7 @@ namespace AddUp.RabbitMQ.Fakes
                 model.ExchangeUnbindNoWait(queueName, exchangeName, routingKey, arguments);
 
                 Assert.True(server.Exchanges[exchangeName].Bindings.IsEmpty);
-                Assert.True(server.Queues[queueName].Bindings.IsEmpty);
+                Assert.Single(server.Queues[queueName].Bindings);
             }
         }
     }

--- a/src/AddUp.FakeRabbitMQ.Tests/FakeModelQueueTests.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/FakeModelQueueTests.cs
@@ -65,7 +65,7 @@ namespace AddUp.RabbitMQ.Fakes
                 model.QueueUnbind(queueName, exchangeName, routingKey, arguments);
                 
                 Assert.True(server.Exchanges[exchangeName].Bindings.IsEmpty);
-                Assert.True(server.Queues[queueName].Bindings.IsEmpty);
+                Assert.Single(server.Queues[queueName].Bindings);
             }
         }
 

--- a/src/AddUp.FakeRabbitMQ/FakeModel.cs
+++ b/src/AddUp.FakeRabbitMQ/FakeModel.cs
@@ -357,6 +357,10 @@ namespace AddUp.RabbitMQ.Fakes
             RabbitQueue updateFunction(string name, RabbitQueue existing) => existing;
             _ = server.Queues.AddOrUpdate(q, queueInstance, updateFunction);
 
+            // RabbitMQ automatically binds queues to the default exchange.
+            // https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default
+            QueueBind(q, "", q, null);
+
             return new QueueDeclareOk(q, 0, 0);
         }
 

--- a/src/AddUp.FakeRabbitMQ/RabbitServer.cs
+++ b/src/AddUp.FakeRabbitMQ/RabbitServer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using RabbitMQ.Client;
 
 namespace AddUp.RabbitMQ.Fakes
 {
@@ -7,6 +8,15 @@ namespace AddUp.RabbitMQ.Fakes
         public RabbitServer()
         {
             Exchanges = new ConcurrentDictionary<string, RabbitExchange>();
+            // Pre-declare the default exchange.
+            // https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default
+            Exchanges[""] = new RabbitExchange(ExchangeType.Direct, this)
+            {
+                Name = "",
+                Arguments = null,
+                AutoDelete = false,
+                IsDurable = true,
+            };
             Queues = new ConcurrentDictionary<string, RabbitQueue>();
         }
 


### PR DESCRIPTION
Make sure that newly declared queues are bound to the default exchange. Add a test to validate this behaviour.