### PR TITLE
Generate a unique consumer tag when the caller does not specify one.

### DIFF
--- a/src/AddUp.FakeRabbitMQ.Tests/FakeModelBasicTests.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/FakeModelBasicTests.cs
@@ -123,6 +123,24 @@ namespace AddUp.RabbitMQ.Fakes
         }
 
         [Fact]
+        public void BasicConsume_generates_consumer_tag_if_none_specified()
+        {
+            var server = new RabbitServer();
+            using (var model = new FakeModel(server))
+            {
+                model.ExchangeDeclare("my_exchange", ExchangeType.Direct);
+                model.QueueDeclare("my_queue");
+                model.ExchangeBind("my_queue", "my_exchange", null);
+
+                var consumer = new FakeAsyncDefaultBasicConsumer(model);
+                var consumerTag = model.BasicConsume("my_queue", false, "", false, false, null, consumer);
+
+                Assert.NotNull(consumerTag);
+                Assert.NotEmpty(consumerTag);
+            }
+        }
+
+        [Fact]
         public void BasicGet_retrieves_message_from_the_queue()
         {
             var server = new RabbitServer();

--- a/src/AddUp.FakeRabbitMQ/FakeModel.cs
+++ b/src/AddUp.FakeRabbitMQ/FakeModel.cs
@@ -98,6 +98,16 @@ namespace AddUp.RabbitMQ.Fakes
                         .HandleBasicDeliver(consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
             }
 
+            // Deliberately check for empty string here, latest RabbitMQ client accepts ""
+            // but will throw on null and kill the channel.
+            if (consumerTag == "")
+            {
+                var guidString = Guid.NewGuid();
+                // https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume.consumer-tag
+                // If this field is empty the server will generate a unique tag.
+                consumerTag = $"amq.{guidString:N}";
+            }
+
             _ = server.Queues.TryGetValue(queue, out var queueInstance);
             if (queueInstance != null)
             {


### PR DESCRIPTION
This is part of the AMQP 0-9-1 protocol as defined in https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume.consumer-tag