### PR TITLE
Make message delivery not synchronous on the thread calling BasicConsume / BasicPublish.

### DIFF
--- a/src/AddUp.FakeRabbitMQ.Tests/ExchangeDirectTests.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/ExchangeDirectTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Threading;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Xunit;
@@ -32,32 +33,41 @@ namespace AddUp.RabbitMQ.Fakes
                 consumerChannel.QueueBind(queueName, exchangeName, bindingKey, null);
 
                 var consumer = new EventingBasicConsumer(consumerChannel);
-                consumer.Received += (s, e) =>
+                using (var messageProcessed = new ManualResetEventSlim(!shouldBeOK))
                 {
-                    var message = Encoding.ASCII.GetString(e.Body.ToArray());
-                    var routingKey = e.RoutingKey;
-                    var exchange = e.Exchange;
+                    consumer.Received += (s, e) =>
+                    {
+                        var message = Encoding.ASCII.GetString(e.Body.ToArray());
+                        var routingKey = e.RoutingKey;
+                        var exchange = e.Exchange;
 
-                    Assert.Equal("hello world!", message);
-                    Assert.Equal("routing-key", routingKey);
-                    Assert.Equal(exchangeName, exchange);
+                        Assert.Equal("hello world!", message);
+                        Assert.Equal("routing-key", routingKey);
+                        Assert.Equal(exchangeName, exchange);
 
-                    ok = true;
-                };
+                        ok = true;
+                        messageProcessed.Set();
+                    };
 
-                consumerChannel.BasicConsume(queueName, autoAck: true, consumer);
+                    consumerChannel.BasicConsume(queueName, autoAck: true, consumer);
 
-                // Publisher
-                using (var publisherConnection = connectionFactory.CreateConnection())
-                using (var publisherChannel = publisherConnection.CreateModel())
-                {
-                    const string message = "hello world!";
-                    var messageBody = Encoding.ASCII.GetBytes(message);
-                    publisherChannel.BasicPublish(exchangeName, "routing-key", false, null, messageBody);
+                    // Publisher
+                    using (var publisherConnection = connectionFactory.CreateConnection())
+                    using (var publisherChannel = publisherConnection.CreateModel())
+                    {
+                        const string message = "hello world!";
+                        var messageBody = Encoding.ASCII.GetBytes(message);
+                        publisherChannel.BasicPublish(exchangeName, "routing-key", false, null, messageBody);
+                    }
+                    messageProcessed.Wait();
                 }
             }
 
             Assert.Equal(ok, shouldBeOK);
+
+            var exchange = rabbitServer.Exchanges[exchangeName];
+            var expectedDroppedMessages = shouldBeOK ? 0 : 1;
+            Assert.Equal(expectedDroppedMessages, exchange.DroppedMessages.Count);
         }
     }
 }

--- a/src/AddUp.FakeRabbitMQ.Tests/ExchangeFanoutTests.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/ExchangeFanoutTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Threading;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Xunit;
@@ -32,30 +33,39 @@ namespace AddUp.RabbitMQ.Fakes
                 consumerChannel.QueueBind(queueName, exchangeName, "whatever", null);
 
                 var consumer = new EventingBasicConsumer(consumerChannel);
-                consumer.Received += (s, e) =>
+                using (var messageProcessed = new ManualResetEventSlim(!shouldBeOK))
                 {
-                    var message = Encoding.ASCII.GetString(e.Body.ToArray());
-                    var exchange = e.Exchange;
+                    consumer.Received += (s, e) =>
+                    {
+                        var message = Encoding.ASCII.GetString(e.Body.ToArray());
+                        var exchange = e.Exchange;
 
-                    Assert.Equal("hello world!", message);
-                    Assert.Equal(exchangeName, exchange);
+                        Assert.Equal("hello world!", message);
+                        Assert.Equal(exchangeName, exchange);
 
-                    ok = true;
-                };
+                        ok = true;
+                        messageProcessed.Set();
+                    };
 
-                consumerChannel.BasicConsume(queueName, autoAck: true, consumer);
+                    consumerChannel.BasicConsume(queueName, autoAck: true, consumer);
 
-                // Publisher
-                using (var publisherConnection = connectionFactory.CreateConnection())
-                using (var publisherChannel = publisherConnection.CreateModel())
-                {
-                    const string message = "hello world!";
-                    var messageBody = Encoding.ASCII.GetBytes(message);
-                    publisherChannel.BasicPublish(exchangeName, routingKey, false, null, messageBody);
+                    // Publisher
+                    using (var publisherConnection = connectionFactory.CreateConnection())
+                    using (var publisherChannel = publisherConnection.CreateModel())
+                    {
+                        const string message = "hello world!";
+                        var messageBody = Encoding.ASCII.GetBytes(message);
+                        publisherChannel.BasicPublish(exchangeName, routingKey, false, null, messageBody);
+                    }
+                    messageProcessed.Wait();
                 }
             }
 
             Assert.Equal(ok, shouldBeOK);
+
+            var exchange = rabbitServer.Exchanges[exchangeName];
+            var expectedDroppedMessages = shouldBeOK ? 0 : 1;
+            Assert.Equal(expectedDroppedMessages, exchange.DroppedMessages.Count);
         }
     }
 }

--- a/src/AddUp.FakeRabbitMQ.Tests/ExchangeHeadersTests.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/ExchangeHeadersTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Threading;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Xunit;
@@ -32,30 +33,39 @@ namespace AddUp.RabbitMQ.Fakes
                 consumerChannel.QueueBind(queueName, exchangeName, "whatever", null);
 
                 var consumer = new EventingBasicConsumer(consumerChannel);
-                consumer.Received += (s, e) =>
+                using (var messageProcessed = new ManualResetEventSlim(!shouldBeOK))
                 {
-                    var message = Encoding.ASCII.GetString(e.Body.ToArray());
-                    var exchange = e.Exchange;
+                    consumer.Received += (s, e) =>
+                    {
+                        var message = Encoding.ASCII.GetString(e.Body.ToArray());
+                        var exchange = e.Exchange;
 
-                    Assert.Equal("hello world!", message);
-                    Assert.Equal(exchangeName, exchange);
+                        Assert.Equal("hello world!", message);
+                        Assert.Equal(exchangeName, exchange);
 
-                    ok = true;
-                };
+                        ok = true;
+                        messageProcessed.Set();
+                    };
 
-                consumerChannel.BasicConsume(queueName, autoAck: true, consumer);
+                    consumerChannel.BasicConsume(queueName, autoAck: true, consumer);
 
-                // Publisher
-                using (var publisherConnection = connectionFactory.CreateConnection())
-                using (var publisherChannel = publisherConnection.CreateModel())
-                {
-                    const string message = "hello world!";
-                    var messageBody = Encoding.ASCII.GetBytes(message);
-                    publisherChannel.BasicPublish(exchangeName, routingKey, false, null, messageBody);
+                    // Publisher
+                    using (var publisherConnection = connectionFactory.CreateConnection())
+                    using (var publisherChannel = publisherConnection.CreateModel())
+                    {
+                        const string message = "hello world!";
+                        var messageBody = Encoding.ASCII.GetBytes(message);
+                        publisherChannel.BasicPublish(exchangeName, routingKey, false, null, messageBody);
+                    }
+                    messageProcessed.Wait();
                 }
             }
 
             Assert.Equal(ok, shouldBeOK);
+
+            var exchange = rabbitServer.Exchanges[exchangeName];
+            var expectedDroppedMessages = shouldBeOK ? 0 : 1;
+            Assert.Equal(expectedDroppedMessages, exchange.DroppedMessages.Count);
         }
     }
 }

--- a/src/AddUp.FakeRabbitMQ.Tests/utils/FakeAsyncDefaultBasicConsumer.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/utils/FakeAsyncDefaultBasicConsumer.cs
@@ -10,19 +10,19 @@ namespace AddUp.RabbitMQ.Fakes
     {
         public FakeAsyncDefaultBasicConsumer(IModel model) : base(model) { }
 
-        public (string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, byte[] body) LastDelivery { get; private set; }
+        public TaskCompletionSource<(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, byte[] body)> LastDelivery { get; } = new TaskCompletionSource<(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, byte[] body)>();
 
-        public string LastCancelOkConsumerTag { get; private set; }
+        public TaskCompletionSource<string> LastCancelOkConsumerTag { get; } = new TaskCompletionSource<string>();
 
         public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, ReadOnlyMemory<byte> body)
         {
-            LastDelivery = (consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body.ToArray());
+            LastDelivery.SetResult((consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body.ToArray()));
             return base.HandleBasicDeliver(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);
         }
 
         public override Task HandleBasicCancelOk(string consumerTag)
         {
-            LastCancelOkConsumerTag = consumerTag;
+            LastCancelOkConsumerTag.SetResult(consumerTag);
             return base.HandleBasicCancelOk(consumerTag);
         }
     }

--- a/src/AddUp.FakeRabbitMQ/FakeModel.cs
+++ b/src/AddUp.FakeRabbitMQ/FakeModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
@@ -14,9 +15,15 @@ namespace AddUp.RabbitMQ.Fakes
         private readonly ConcurrentDictionary<ulong, RabbitMessage> workingMessages = new ConcurrentDictionary<ulong, RabbitMessage>();
         private readonly ConcurrentDictionary<string, IBasicConsumer> consumers = new ConcurrentDictionary<string, IBasicConsumer>();
         private readonly RabbitServer server;
+        private readonly BlockingCollection<Action> Deliveries = new BlockingCollection<Action>();
+        private readonly Task DeliveriesTask;
         private long lastDeliveryTag;
 
-        public FakeModel(RabbitServer rabbitServer) => server = rabbitServer;
+        public FakeModel(RabbitServer rabbitServer)
+        {
+            server = rabbitServer;
+            DeliveriesTask = Task.Run(HandleDeliveries);
+        }
 
 #pragma warning disable 67
         public event EventHandler<BasicAckEventArgs> BasicAcks;
@@ -105,9 +112,9 @@ namespace AddUp.RabbitMQ.Fakes
                 _ = consumers.AddOrUpdate(consumerTag, consumer, updateFunction);
 
                 foreach (var message in queueInstance.Messages)
-                    notifyConsumerOfMessage(message);
-                queueInstance.MessagePublished += (sender, message) => 
-                    notifyConsumerOfMessage(message);
+                    Deliveries.Add(() => notifyConsumerOfMessage(message));
+                queueInstance.MessagePublished += (sender, message) =>
+                    Deliveries.Add(() => notifyConsumerOfMessage(message));
 
                 if (consumer is IAsyncBasicConsumer asyncBasicConsumer)
                     asyncBasicConsumer.HandleBasicConsumeOk(consumerTag).GetAwaiter().GetResult();
@@ -240,6 +247,8 @@ namespace AddUp.RabbitMQ.Fakes
             try
             {
                 CloseReason = reason;
+                Deliveries.CompleteAdding();
+                DeliveriesTask.Wait();
                 ModelShutdown?.Invoke(this, reason);
             }
             catch
@@ -263,6 +272,7 @@ namespace AddUp.RabbitMQ.Fakes
         public void Dispose()
         {
             if (IsOpen) Abort();
+            Deliveries.Dispose();
         }
 
         public void ExchangeBind(string destination, string source, string routingKey, IDictionary<string, object> arguments)
@@ -436,5 +446,42 @@ namespace AddUp.RabbitMQ.Fakes
 
         public void WaitForConfirmsOrDie() => WaitForConfirmsOrDie(Timeout.InfiniteTimeSpan);
         public void WaitForConfirmsOrDie(TimeSpan timeout) => _ = WaitForConfirms(timeout);
+
+        /// <summary>
+        /// Rabbit docs state that each connection is backed by a single background thread:
+        /// 
+        /// https://www.rabbitmq.com/dotnet-api-guide.html#concurrency-thread-usage
+        /// 
+        /// However, this is not actually true, it's backed by a Task:
+        /// 
+        /// https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/65dd5f92dda130ec35b4ad6fe7bc54dbcb1637fd/projects/RabbitMQ.Client/client/impl/ConsumerWorkService.cs#L81
+        /// 
+        /// FakeModels aren't aware of their connection, so in order to emulate this, just
+        /// run a task that handles deliveries per task. It's necessary to match RabbitMQ
+        /// semantics as running delivery callbacks synchronously can cause deadlocks in
+        /// code under test.
+        /// </summary>
+        private void HandleDeliveries()
+        {
+            try
+            {
+                foreach (var delivery in Deliveries.GetConsumingEnumerable())
+                {
+                    try
+                    {
+                        delivery();
+                    }
+                    catch (Exception ex)
+                    {
+                        var callbackArgs = CallbackExceptionEventArgs.Build(ex, "");
+                        CallbackException(this, callbackArgs);
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Swallow exceptions so Close() doesn't have to deal with it.
+            }
+        }
     }
 }


### PR DESCRIPTION
This is to better mimic the behaviour of the actual `RabbitMQ.Client` library, which runs message deliveries in one or more tasks. This is important for my use-case, as I have code that relies on this threading model, and deadlocks if message deliveries are synchronous.