### PR TITLE
Improve logic around cancelling consumers and closing models.

### DIFF
--- a/src/AddUp.FakeRabbitMQ.Tests/FakeModelAbortAndCloseTests.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/FakeModelAbortAndCloseTests.cs
@@ -71,6 +71,19 @@ namespace AddUp.RabbitMQ.Fakes
         }
 
         [Fact]
+        public void BasicClose_only_fires_model_shutdown_once()
+        {
+            var server = new RabbitServer();
+            var model = new FakeModel(server);
+            var shutdownCount = 0;
+            model.ModelShutdown += (o, ea) => ++shutdownCount;
+            model.Close();
+            model.Close();
+            model.Close();
+            Assert.Equal(1, shutdownCount);
+        }
+
+        [Fact]
         public void Abort_closes_the_channel()
         {
             var server = new RabbitServer();

--- a/src/AddUp.FakeRabbitMQ/ConsumeData.cs
+++ b/src/AddUp.FakeRabbitMQ/ConsumeData.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using RabbitMQ.Client;
+
+namespace AddUp.RabbitMQ.Fakes
+{
+    internal class ConsumerData
+    {
+        public ConsumerData(IBasicConsumer consumer, RabbitQueue queue, EventHandler<RabbitMessage> queueMessagePublished)
+        {
+            Consumer = consumer;
+            Queue = queue;
+            QueueMessagePublished = queueMessagePublished;
+        }
+
+        public IBasicConsumer Consumer { get; }
+        public RabbitQueue Queue { get; }
+        public EventHandler<RabbitMessage> QueueMessagePublished { get; }
+    }
+}

--- a/src/AddUp.FakeRabbitMQ/FakeModel.cs
+++ b/src/AddUp.FakeRabbitMQ/FakeModel.cs
@@ -503,6 +503,7 @@ namespace AddUp.RabbitMQ.Fakes
                     {
                         try
                         {
+                            if (!IsOpen) break;
                             delivery();
                         }
                         catch (Exception ex)


### PR DESCRIPTION
There are a couple of fixes in here, which are separated out into separate commits, specifically:

- Forbidding duplicate consumer tags.
- Cancelling consumers when a model is closed / disposed.
- Making sure received events wouldn't fire after consumers were cancelled.
- Cancel delivery of any more messages once the model is closed, to more closely mirror the RabbitMQ client.
- Fixing a nasty deadlock issue when calling Close from inside a Received callback. This is not perfect, as if you manage to switch execution contexts inside the Receive handler it can still throw, but that's very difficult to handle. I was attempting to remove this `Wait` but attempting to do so unearths a limitation of the `FakeConnectionFactory` that breaks the `ExchangeHeadersTests` and `ExchangeFanoutTests` because they use two connections. This is something I'd like to look into more in the future but I don't have time right now.

Apologies for the several disparate changes in a single MR, I kept going until my code under test passed tests following the upgrade to `2.3.0`. Hopefully the fact that it's in different commits allows for easy review, but if you'd like me to split it into separate MRs, please do let me know (and thanks for all your time reviewing my MRs recently, @odalet !)