### PR TITLE
Create fresh connections rather than reusing a singleton

### DIFF
--- a/src/AddUp.FakeRabbitMQ.Tests/FakeConnectionFactoryTests.cs
+++ b/src/AddUp.FakeRabbitMQ.Tests/FakeConnectionFactoryTests.cs
@@ -64,13 +64,6 @@ namespace AddUp.RabbitMQ.Fakes
         }
 
         [Fact]
-        public void Connection_is_null_when_no_connection_was_provided()
-        {
-            var factory = new FakeConnectionFactory();
-            Assert.Null(factory.GetCurrentConnectionForUnitTests());
-        }
-
-        [Fact]
         public void Properties_retain_their_values_when_set()
         {
             var factory = new FakeConnectionFactory

--- a/src/AddUp.FakeRabbitMQ/FakeConnection.cs
+++ b/src/AddUp.FakeRabbitMQ/FakeConnection.cs
@@ -94,10 +94,6 @@ namespace AddUp.RabbitMQ.Fakes
         public void Close(ushort reasonCode, string reasonText, TimeSpan timeout) =>
             Close(new ShutdownEventArgs(ShutdownInitiator.Application, reasonCode, reasonText), abort: false);
 
-        // Not part of the original implementation. Required by FakeConnectionFactory
-        // NB: does not recreate the models
-        internal void ForceOpen() => CloseReason = null;
-
         private void Close(ShutdownEventArgs reason, bool abort)
         {
             try

--- a/src/AddUp.FakeRabbitMQ/FakeConnectionFactory.cs
+++ b/src/AddUp.FakeRabbitMQ/FakeConnectionFactory.cs
@@ -25,8 +25,6 @@ namespace AddUp.RabbitMQ.Fakes
         public TimeSpan HandshakeContinuationTimeout { get; set; }
         public TimeSpan ContinuationTimeout { get; set; }
 
-        private FakeConnection UnderlyingConnection { get; set; }
-
         public IAuthMechanismFactory AuthMechanismFactory(IList<string> mechanismNames) =>
             new PlainMechanismFactory();
 
@@ -38,14 +36,7 @@ namespace AddUp.RabbitMQ.Fakes
 
         public IConnection CreateConnection(string clientProvidedName)
         {
-            if (UnderlyingConnection == null)
-                UnderlyingConnection = new FakeConnection(server, clientProvidedName);
-            else
-                UnderlyingConnection.ForceOpen();
-
-            return UnderlyingConnection;
+            return new FakeConnection(server, clientProvidedName);
         }
-
-        internal IConnection GetCurrentConnectionForUnitTests() => UnderlyingConnection;
     }
 }


### PR DESCRIPTION
Follow-up to changes in #120

Fixes issues where connections are expected to be isolated and unique (e.g. consumer vs publisher connections). Previously, closing one connection effectively closed all of them.

Some of the tests in this solution are having occasional deadlocks because of this.