### PR TITLE
Updated RabbitMQ.Client to 6.5.0

### DIFF
--- a/src/AddUp.FakeRabbitMQ/AddUp.FakeRabbitMQ.csproj
+++ b/src/AddUp.FakeRabbitMQ/AddUp.FakeRabbitMQ.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.55.0.65544">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/AddUp.FakeRabbitMQ/FakeConnection.cs
+++ b/src/AddUp.FakeRabbitMQ/FakeConnection.cs
@@ -30,6 +30,7 @@ namespace AddUp.RabbitMQ.Fakes
         public event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
         public event EventHandler<ConsumerTagChangedAfterRecoveryEventArgs> ConsumerTagChangeAfterRecovery;
         public event EventHandler<QueueNameChangedAfterRecoveryEventArgs> QueueNameChangeAfterRecovery;
+        public event EventHandler<RecoveringConsumerEventArgs> RecoveringConsumer;
 #pragma warning restore 67
 
         public string ClientProvidedName { get; }

--- a/src/AddUp.FakeRabbitMQ/FakeModel.cs
+++ b/src/AddUp.FakeRabbitMQ/FakeModel.cs
@@ -40,6 +40,7 @@ namespace AddUp.RabbitMQ.Fakes
         public int ChannelNumber { get; }
         public IBasicConsumer DefaultConsumer { get; set; }
         public ulong NextPublishSeqNo { get; set; }
+        public string CurrentQueue { get; private set; }
         public TimeSpan ContinuationTimeout { get; set; }
         public ShutdownEventArgs CloseReason { get; private set; }
         public bool IsOpen => CloseReason == null;
@@ -401,6 +402,8 @@ namespace AddUp.RabbitMQ.Fakes
             // RabbitMQ automatically binds queues to the default exchange.
             // https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default
             QueueBind(q, "", q, null);
+
+            CurrentQueue = queue;
 
             return new QueueDeclareOk(q, 0, 0);
         }


### PR DESCRIPTION
Updated to 6.5.0
* FakeConnection.RecoveringConsumer is ignored.
* FakeModel.CurrentQueue is updated in QueueDeclare
  Documentation states: The name of the last queue declared on this channel.