### PR TITLE
Bump RabbitMQ.Client to 6.8.0

### DIFF
--- a/src/AddUp.FakeRabbitMQ/AddUp.FakeRabbitMQ.csproj
+++ b/src/AddUp.FakeRabbitMQ/AddUp.FakeRabbitMQ.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="9.15.0.81779">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The RabbitMQ client introduced a breaking API change in a `ShutdownEventArgs` constructor in 6.8.0: https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/1438

So this lib needs to be recompiled against the new version of RabbitMQ to be fully compatible.

@lukebakken FYI about RabbitMQ.Client 6.8.0. Not sure what the breaking changes policy is, if this is even considered one.